### PR TITLE
create user by role routes to avoid sending role in the request body

### DIFF
--- a/api/src/Controller/CreateHomeownerAction.php
+++ b/api/src/Controller/CreateHomeownerAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Controller;
+
+
+
+use App\Entity\User;
+use App\Repository\PropertyRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use App\Service\CreateUser;
+
+#[AsController]
+class CreateHomeownerAction extends AbstractController
+{
+    public function __invoke(Request $request, PropertyRepository $propertyRepository, CreateUser $createUser): Response
+    {
+        $data = $request->toArray();
+        return $createUser->create($data, [User::ROLE_HOMEOWNER]);
+    }
+}

--- a/api/src/Controller/CreateTenantAction.php
+++ b/api/src/Controller/CreateTenantAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Controller;
+
+
+
+use App\Entity\User;
+use App\Repository\PropertyRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use App\Service\CreateUser;
+
+#[AsController]
+class CreateTenantAction extends AbstractController
+{
+    public function __invoke(Request $request, PropertyRepository $propertyRepository, CreateUser $createUser): Response
+    {
+        $data = $request->toArray();
+        return $createUser->create($data, [User::ROLE_TENANT]);
+    }
+}

--- a/api/src/Controller/RegistrationController.php
+++ b/api/src/Controller/RegistrationController.php
@@ -2,11 +2,9 @@
 
 namespace App\Controller;
 
-use App\Entity\User;
 use App\Form\RegistrationFormType;
 use App\Repository\UserRepository;
 use App\Security\EmailVerifier;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,74 +12,26 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\ExpiredSignatureException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
-class RegistrationController extends AbstractController
+class  RegistrationController extends AbstractController
 {
     private EmailVerifier $emailVerifier;
-    private UserPasswordHasherInterface $userPasswordHasher;
-    private EntityManagerInterface $entityManager;
     private ValidatorInterface $validator;
     private UserRepository $userRepository;
 
     public function __construct(EmailVerifier $emailVerifier, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager, ValidatorInterface $validator, UserRepository $userRepository)
     {
         $this->emailVerifier = $emailVerifier;
-        $this->userPasswordHasher = $userPasswordHasher;
-        $this->entityManager = $entityManager;
         $this->validator = $validator;
         $this->userRepository = $userRepository;
-    }
-
-    #[Route('/register', name: 'app_register')]
-    public function register(Request $request): Response
-    {
-        $data = $request->toArray();
-
-        $user = new User();
-        if (isset($data['email'])) $user->setEmail($data['email']);
-        if (isset($data['roles']) && count($data['roles']) === 1) {
-            if (count(array_diff($data['roles'], User::ALLOWED_ROLES)) > 0) {
-                return new JsonResponse(['message' => 'Rôle(s) non valide(s)'], 400);
-            } else {
-                $user->setRoles($data['roles']);
-            }
-        } else {
-            return new JsonResponse(['message' => 'Rôle(s) non valide(s)'], 400);
-        }
-        if (isset($data['plainPassword'])) $user->setPassword($this->userPasswordHasher->hashPassword($user, $data['plainPassword']));
-
-        $errors = $this->validator->validate($user, null, ['registration']);
-        if (count($errors) > 0) {
-            $errorsOutput = [];
-            foreach ($errors as $error) {
-                $errorsOutput[$error->getPropertyPath()][] = $error->getMessage();
-            }
-            return new JsonResponse(['errors' => $errorsOutput], 400);
-        }
-        $this->entityManager->persist($user);
-        try {
-            $this->entityManager->flush();
-        } catch (UniqueConstraintViolationException $e) {
-            return new JsonResponse(['message' => 'Un compte avec cet email existe déjà'], 400);
-        }
-
-        $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
-            (new TemplatedEmail())
-                ->from(new Address('mailer@easyhome.com', 'Easyhome Mail Bot'))
-                ->to($user->getEmail())
-                ->subject('Please Confirm your Email')
-                ->htmlTemplate('registration/confirmation_email.html.twig')
-        );
-
-        return new JsonResponse(['message' => 'Un mail vous a été envoyé. Cliquez sur le lien pour compléter votre inscription.'], 201);
     }
 
     #[Route('/test', name: 'app_super_test')]
@@ -127,26 +77,26 @@ class RegistrationController extends AbstractController
     public function requestVerifyUserEmail(Request $request): JsonResponse {
 
         if ($this->getUser()) {
-            return new JsonResponse(['message' => 'Vous êtes déjà connecté'], 400);
+            throw new BadRequestHttpException('Vous êtes déjà connecté');
         }
         $data = $request->toArray();
         if (!isset($data['email'])) {
-            return new JsonResponse(['message' => 'Email manquant'], 400);
+            throw new BadRequestHttpException('Email manquant');
         }
         $errors = $this->validator->validate($data['email'], new Email());
         if (count($errors) > 0) {
-            $errorsOutput = [];
+            $errorsOutput = "";
             foreach ($errors as $error) {
-                $errorsOutput[$error->getPropertyPath()][] = $error->getMessage();
+                $errorsOutput.$error->getPropertyPath()." : ".$error->getMessage() ."\n";
             }
-            return new JsonResponse(['errors' => $errorsOutput], 400);
+            throw new BadRequestHttpException( $errorsOutput);
         }
         $user =  $this->userRepository->findOneBy(['email' => $data['email']]);
         if (!$user) {
-            return new JsonResponse(['message' => 'Aucun utilisateur avec cet email'], 400);
+            throw new BadRequestHttpException('Aucun utilisateur avec cet email');
         }
         if ($user->isVerified()) {
-            return new JsonResponse(['message' => 'Votre email est déjà validé'], 400);
+            throw new BadRequestHttpException('Votre email est déjà validé');
         }
         $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
         (new TemplatedEmail())
@@ -155,6 +105,6 @@ class RegistrationController extends AbstractController
             ->subject('Please Confirm your Email')
             ->htmlTemplate('registration/confirmation_email.html.twig')
         );
-        return new JsonResponse(['message' => 'Un mail vous a été envoyé. Cliquez sur le lien pour compléter votre inscription.'], 201);
+        throw new BadRequestHttpException('Un mail vous a été envoyé. Cliquez sur le lien pour compléter votre inscription.');
     }
 }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -12,6 +12,8 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use App\Controller\CreateHomeownerAction;
+use App\Controller\CreateTenantAction;
 use App\Controller\UserController;
 use App\Enums\UserValidationStatusEnum;
 use App\Enums\WorkSituationEnum;
@@ -51,6 +53,18 @@ use Symfony\Component\Validator\Constraints as Assert;
     normalizationContext: ['groups' => ['user_read', 'all']],
     denormalizationContext: ['groups' => ['user_write']],
 )]
+#[Post(
+    uriTemplate: '/users/register_tenant',
+    controller: CreateTenantAction::class,
+    denormalizationContext: ['groups' => ['create_user']],
+    name: 'register_tenant'
+)]
+#[Post(
+    uriTemplate: '/users/register_homeowner',
+    controller: CreateHomeownerAction::class,
+    denormalizationContext: ['groups' => ['create_user']],
+    name: 'register_homeowner'
+)]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]
 #[UniqueEntity('email')]
@@ -73,7 +87,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[Assert\NotBlank(groups: ['register'])]
     #[Assert\Email(groups: ['register'])]
-    #[Groups(['user_read', 'user_write', 'property_read'])]
+    #[Groups(['user_read', 'user_write', 'property_read', 'create_user'])]
     #[ORM\Column(length: 255, unique: true)]
     private ?string $email = null;
 
@@ -81,7 +95,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $password = null;
 
     #[Assert\NotBlank(groups: ['register'])]
-    #[Groups(['user_write'])]
+    #[Groups(['user_write', 'create_user'])]
     private ?string $plainPassword = null;
 
     #[ORM\Column(type: 'json')]

--- a/api/src/Serializer/ErrorNormalizer.php
+++ b/api/src/Serializer/ErrorNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Serializer;
+
+use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Problem\Serializer\ErrorNormalizerTrait;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+{
+    use ErrorNormalizerTrait;
+
+    public const FORMAT = 'jsonld';
+    public const TITLE = 'title';
+    private array $defaultContext = [self::TITLE => 'An error occurred'];
+
+    public function __construct(private readonly UrlGeneratorInterface $urlGenerator, private readonly bool $debug = false, array $defaultContext = [])
+    {
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function normalize(mixed $object, string $format = null, array $context = []): float|int|bool|\ArrayObject|array|string|null
+    {
+        $data = [
+            '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'Error']),
+            '@type' => 'hydra:Error',
+            'hydra:title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
+            'hydra:description' => $this->getErrorMessage($object, $context, $this->debug),
+        ];
+
+        if ($this->debug && null !== $trace = $object->getTrace()) {
+            $data['trace'] = $trace;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportsNormalization(mixed $data, string $format = null): bool
+    {
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}

--- a/api/src/Service/CreateUser.php
+++ b/api/src/Service/CreateUser.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Security\EmailVerifier;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CreateUser
+{
+    private EmailVerifier $emailVerifier;
+    private UserPasswordHasherInterface $userPasswordHasher;
+    private EntityManagerInterface $entityManager;
+    private ValidatorInterface $validator;
+    private UserRepository $userRepository;
+
+    public function __construct(EmailVerifier $emailVerifier, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager, ValidatorInterface $validator, UserRepository $userRepository)
+    {
+        $this->emailVerifier = $emailVerifier;
+        $this->userPasswordHasher = $userPasswordHasher;
+        $this->entityManager = $entityManager;
+        $this->validator = $validator;
+        $this->userRepository = $userRepository;
+    }
+
+    public function create(Array $data, Array $roles): Response
+    {
+        $user = new User();
+        if (isset($data['email'])) $user->setEmail($data['email']);
+        if (isset($data['plainPassword'])) $user->setPassword($this->userPasswordHasher->hashPassword($user, $data['plainPassword']));
+        $user->setRoles($roles);
+        $errors = $this->validator->validate($user, null, ['registration']);
+        if (count($errors) > 0) {
+            $errorsOutput = '';
+            foreach ($errors as $error) {
+                $errorsOutput . $error->getPropertyPath() . ': ' . $error->getMessage() . '\\n';
+            }
+            throw new BadRequestHttpException($errorsOutput);
+        }
+        $this->entityManager->persist($user);
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException $e) {
+            throw new BadRequestHttpException('Un compte avec cet email existe déjà');
+        }
+
+        $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
+            (new TemplatedEmail())
+                ->from(new Address('mailer@easyhome.com', 'Easyhome Mail Bot'))
+                ->to($user->getEmail())
+                ->subject('Please Confirm your Email')
+                ->htmlTemplate('registration/confirmation_email.html.twig')
+        );
+        return new JsonResponse('Un mail vous a été envoyé. Cliquez sur le lien pour compléter votre inscription.', 201);
+    }
+}

--- a/app/src/components/FileInput.vue
+++ b/app/src/components/FileInput.vue
@@ -47,7 +47,7 @@ async function onUpload() {
     console.log("err: ", error)
     message.value.text = '';
     message.value.type = '';
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
 

--- a/app/src/components/Homeowner/AddPropertyForm.vue
+++ b/app/src/components/Homeowner/AddPropertyForm.vue
@@ -224,7 +224,7 @@
             } catch(error: any) {
                 console.log(error);
                 errorType.value = error.response.data.error_type || '';
-                message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+                message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
                 message.value.type = 'error';
             }
         } else {

--- a/app/src/components/Homeowner/RequestSlotsProposals.vue
+++ b/app/src/components/Homeowner/RequestSlotsProposals.vue
@@ -88,7 +88,7 @@ async function loadVisits() {
     })
     .catch((error) => {
         errorType.value = error.response.data.error_type || '';
-        message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+        message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
         message.value.type = 'error';
 
     });

--- a/app/src/components/PropertiesGrid.vue
+++ b/app/src/components/PropertiesGrid.vue
@@ -64,7 +64,7 @@ async function get_page(pageNumber = 1) {
     console.log("err: ", error)
     message.value.text = '';
     message.value.type = '';
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
   loading.value = false;

--- a/app/src/components/Property.vue
+++ b/app/src/components/Property.vue
@@ -60,7 +60,7 @@ async function getPhotoLink(id:String) {
     console.log("err: ", error)
     message.value.text = '';
     message.value.type = '';
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
 }

--- a/app/src/components/PropertyDetails.vue
+++ b/app/src/components/PropertyDetails.vue
@@ -42,7 +42,7 @@ async function getPhotoLink(id:String) {
 
   } catch (error: any) {
     console.log("err: ", error)
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
 }
@@ -61,7 +61,7 @@ async function getMyProperty(id:any) {
 
   } catch (error: any) {
     console.log("err: ", error)
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
 }
@@ -80,7 +80,7 @@ const createRequest = async () => {
     message.value.type = 'success';
   } catch (error: any) {
     console.log("err: ", error)
-    message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+    message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
     message.value.type = 'error';
   }
   alreadyRequested.value = true;

--- a/app/src/components/RegisterForm.vue
+++ b/app/src/components/RegisterForm.vue
@@ -18,12 +18,7 @@
     </v-row>
     <v-alert v-if="message.content" class="mb-3 text-white" :color="message.type">
       <div v-if="message.type === 'error'">
-        <template v-for="(messages, field) in message.content" :key="field">
-          <li>{{ field }}: </li>
-          <template v-for="(message, index) in messages" :key="index">
-            <li class="error-message pl-6"> - {{ message }} </li>
-          </template>
-        </template>
+        {{ message.content }}
       </div>
       <div v-else>
         {{ message.content }}
@@ -95,21 +90,27 @@ const message = ref({
 const loading = ref<Boolean>(false);
 
 const register = async (event: MouseEvent) =>{
-    event.preventDefault();
+  event.preventDefault();
   loading.value = true;
-  if (valid.value) {
-    type FormUserData = Omit<User, "passwordConfirm" | "password"> & { plainPassword: string };
+  let url_by_role = '';
+  if(props.for === Roles.Tenant) {
+    url_by_role = `${import.meta.env.VITE_BASE_API_URL}/users/register_tenant`;
+  }else if(props.for === Roles.Homeowner) {
+    url_by_role = `${import.meta.env.VITE_BASE_API_URL}/users/register_homeowner`;
+  }
+  if (valid.value && url_by_role !== '') {
+    type FormUserData = Omit<User, "passwordConfirm" | "password" | "roles"> & { plainPassword: string };
     const data: FormUserData = {
       email: user.email,
-      plainPassword: user.password,
-      roles: [props.for as Roles]
+      plainPassword: user.password
     };
     try {
-      const response = await axios.post(`${import.meta.env.VITE_BASE_API_URL}/register`, data, {headers: {'Content-Type': 'application/json'}});
-      message.value.content = response.data.message;
+      const response = await axios.post(url_by_role, data, {headers: {'Content-Type': 'application/json'}});
+      console.log(response)
+      message.value.content = response.data;
       message.value.type = 'success';
     } catch (error: any) {
-      message.value.content = error.response.data.errors;
+      message.value.content =  error.response.data.detail;
       message.value.type = 'error';
       console.log(error);
     }

--- a/app/src/views/Agency/ShowUserView.vue
+++ b/app/src/views/Agency/ShowUserView.vue
@@ -32,7 +32,7 @@
             user.value.validationStatus = response.data.validationStatus;
             baseValidatedDocuments.value = user.value.documents.filter((document: any) => document.isValid);
         } catch (error: any) {
-            message.value = { text: error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.', type: 'error' };
+            message.value = { text: error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.', type: 'error' };
             console.log(error.response.data);
         }
         loading.value = false;

--- a/app/src/views/RequestNewLinkView.vue
+++ b/app/src/views/RequestNewLinkView.vue
@@ -25,7 +25,7 @@ import { Roles } from "@/enums/roles";
       message.value.text = response.message;
       message.value.type = 'success';
     } catch (error: any) {
-      message.value.text = error.response.data.message || 'Une erreur est survenue. Veuillez réessayer.';
+      message.value.text = error.response.data.detail || 'Une erreur est survenue. Veuillez réessayer.';
       message.value.type = 'error';
     }
     loading.value = false;


### PR DESCRIPTION
- add users/register_homeowner and register_tenant to avoid sending role in the request
- register agency will be done from the back or via post /user which allowed for ROLE_AGENCY or ROLE_ADMIN
- modifying RegisterForm.vue to send the request depending on props.for
- fixing bug error.response.data.message to error.response.data.detail